### PR TITLE
hyperfs: disable dentry cache

### DIFF
--- a/src/hyperfs/hyperfs.c
+++ b/src/hyperfs/hyperfs.c
@@ -1480,43 +1480,9 @@ static void hyperfs_d_release(struct dentry *dentry)
 	dput(real);
 }
 
-static int hyperfs_d_revalidate(struct dentry *dentry, unsigned int flags)
-{
-	struct dentry *real = dentry->d_fsdata;
-	int ret = 1;
-
-	if (!real)
-		return 0;
-
-	if (real->d_flags & DCACHE_OP_REVALIDATE) {
-		ret = real->d_op->d_revalidate(real, flags);
-		if (ret < 0)
-			return ret;
-		if (!ret) {
-			if (!(flags & LOOKUP_RCU))
-				d_invalidate(real);
-			return -ESTALE;
-		}
-	}
-
-	return 1;
-}
-
-static int hyperfs_d_weak_revalidate(struct dentry *dentry, unsigned int flags)
-{
-	struct dentry *real = dentry->d_fsdata;
-	int ret = 1;
-
-	if (real && (real->d_flags & DCACHE_OP_WEAK_REVALIDATE))
-		ret = real->d_op->d_weak_revalidate(real, flags);
-
-	return ret;
-}
-
 static const struct dentry_operations hyperfs_dentry_operations = {
 	.d_release = hyperfs_d_release,
-	.d_revalidate = hyperfs_d_revalidate,
-	.d_weak_revalidate = hyperfs_d_weak_revalidate,
+	.d_delete = always_delete_dentry,
 };
 
 static int hyperfs_parse_options(char *options, struct super_block *sb,


### PR DESCRIPTION
Instead of caching dentries separately from the underlying filesystem and trying to revalidate them when the underlying filesystem changes, disable caching dentries entirely, so the don't need to be revalidated. The kernel does something similar in its implementation of the 9p network filesystem when caching is disabled: https://elixir.bootlin.com/linux/v6.13/source/fs/9p/vfs_dentry.c#L109-L112. Network filesystems are a good analogue for hyperfs here, since they also need to handle the case of an underlying filesystem that changes outside of normal interfaces. This fixes some issues with `/proc/PID` accesses returning `ESTALE`.