### PR TITLE
syscalls_hc: use mutex instead of rcu

### DIFF
--- a/src/hooks/syscalls_hc.h
+++ b/src/hooks/syscalls_hc.h
@@ -81,7 +81,7 @@ struct kernel_syscall_hook {
 
 /* Global variables - defined in syscalls_hc.c */
 extern struct hlist_head syscall_hook_table[1024];
-extern spinlock_t syscall_hook_lock;
+extern struct mutex syscall_hook_lock;
 
 
 /* Unregister a syscall hook using its pointer */

--- a/src/portal/portal_syscall.c
+++ b/src/portal/portal_syscall.c
@@ -9,7 +9,7 @@
 extern struct hlist_head syscall_hook_table[1024];
 extern struct hlist_head syscall_name_table[1024];
 extern struct hlist_head syscall_all_hooks;
-extern spinlock_t syscall_hook_lock;
+extern struct mutex syscall_hook_lock;
 
 // Using normalize_syscall_name and syscall_name_hash from syscalls_hc.h
 
@@ -48,7 +48,7 @@ void handle_op_register_syscall_hook(portal_region *mem_region)
     }
     
     // Add to the main hook table indexed by pointer address
-    spin_lock(&syscall_hook_lock);
+    mutex_lock(&syscall_hook_lock);
     hash_add_rcu(syscall_hook_table, &kernel_hook->hlist, (unsigned long)kernel_hook);
     
     // Also add to name-based hash table for faster lookups
@@ -61,7 +61,7 @@ void handle_op_register_syscall_hook(portal_region *mem_region)
         hash_add_rcu(syscall_name_table, &kernel_hook->name_hlist, name_hash);
     }
     
-    spin_unlock(&syscall_hook_lock);
+    mutex_unlock(&syscall_hook_lock);
     
     // Return the hook's memory address in the size field
     mem_region->header.size = (unsigned long)kernel_hook;


### PR DESCRIPTION
Fixes #4.

I haven't done performance benchmarks, but with this change all the riscv64 tests pass except kffi.