### PR TITLE
feat(mmap): Add native QEMU mmap support in guest

### DIFF
--- a/src/portal/portal_anon.c
+++ b/src/portal/portal_anon.c
@@ -9,11 +9,13 @@
 struct portal_anonfs_create_req {
     char name[32];
     int hf_id;
+    uint64_t mmap_phys_addr;
     struct igloo_dev_ops ops;
 };
 
 struct portal_anonfs_entry {
     int hf_id;
+    uint64_t mmap_phys_addr;
     struct file_operations fops;
     int (*python_release)(struct inode *, struct file *);
 };
@@ -37,6 +39,18 @@ static int igloo_anonfs_proxy_release(struct inode *inode, struct file *file) {
     return ret;
 }
 
+static int igloo_anonfs_proxy_mmap(struct file *file, struct vm_area_struct *vma) {
+    struct portal_anonfs_entry *pe = file->private_data;
+    size_t size = vma->vm_end - vma->vm_start;
+
+    if (pe && pe->mmap_phys_addr) {
+        vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+        return remap_pfn_range(vma, vma->vm_start, pe->mmap_phys_addr >> PAGE_SHIFT,
+                               size, vma->vm_page_prot);
+    }
+    return -ENODEV;
+}
+
 void handle_op_anonfs_create_file(portal_region *mem_region) {
     struct portal_anonfs_create_req *req = (void *)PORTAL_DATA(mem_region);
     struct portal_anonfs_entry *pe;
@@ -50,6 +64,7 @@ void handle_op_anonfs_create_file(portal_region *mem_region) {
 
     req->name[31] = '\0';
     pe->hf_id = req->hf_id;
+    pe->mmap_phys_addr = req->mmap_phys_addr;
     pe->python_release = req->ops.release;
 
     // Use the shared converter to wire up Python trampolines
@@ -57,6 +72,10 @@ void handle_op_anonfs_create_file(portal_region *mem_region) {
     
     // Route release through our cleanup proxy
     pe->fops.release = igloo_anonfs_proxy_release;
+
+    if (pe->mmap_phys_addr) {
+        pe->fops.mmap = igloo_anonfs_proxy_mmap;
+    }
 
     fd = anon_inode_getfd(req->name, &pe->fops, pe, O_RDWR);
     

--- a/src/portal/portal_devfs.c
+++ b/src/portal/portal_devfs.c
@@ -31,6 +31,7 @@ struct portal_devfs_dir_req {
 struct portal_devfs_create_req {
     char name[64];
     uint64_t size;
+    uint64_t mmap_phys_addr;
     int support_mmap;
     int is_block;
     int logical_block_size;
@@ -60,6 +61,7 @@ struct portal_devfs_entry {
     // MMAP / Release support
     struct mutex shm_lock;
     struct file *shm_file;
+    uint64_t mmap_phys_addr;
     int (*python_release)(struct inode *, struct file *);
     char *name;
 };
@@ -176,12 +178,19 @@ static int igloo_devfs_proxy_mmap(struct file *file, struct vm_area_struct *vma)
 
     if (!inode || !inode->i_cdev) return -ENODEV;
     
-    // Resolve tracking struct from cdev
+    // resolve tracking struct from cdev
     pe = container_of(inode->i_cdev, struct portal_devfs_entry, cdev);
 
     if (!pe) {
         printk(KERN_ERR "igloo_mmap: No portal tracking data found for devfs inode\n");
         return -ENODEV;
+    }
+
+    if (pe->mmap_phys_addr) {
+        // NATIVE QEMU MMAP: Directly map the physical address assigned by Penguin
+        vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+        return remap_pfn_range(vma, vma->vm_start, pe->mmap_phys_addr >> PAGE_SHIFT,
+                               size, vma->vm_page_prot);
     }
 
     mutex_lock(&pe->shm_lock);
@@ -504,6 +513,7 @@ void handle_op_devfs_create_device(portal_region *mem_region)
 
     mutex_init(&pe->shm_lock);
     pe->name = kstrdup(req->name, GFP_KERNEL);
+    pe->mmap_phys_addr = req->mmap_phys_addr;
     pe->python_release = req->ops.release;
     pe->is_block = req->is_block;
 

--- a/src/portal/portal_procfs.c
+++ b/src/portal/portal_procfs.c
@@ -80,6 +80,13 @@ int igloo_proxy_mmap(struct file *file, struct vm_area_struct *vma)
         return -ENODEV;
     }
 
+    if (pe->mmap_phys_addr) {
+        // NATIVE QEMU MMAP: Directly map the physical address assigned by Penguin
+        vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+        return remap_pfn_range(vma, vma->vm_start, pe->mmap_phys_addr >> PAGE_SHIFT,
+                               size, vma->vm_page_prot);
+    }
+
     // Lock to ensure only the first mmap call triggers the hypervisor fetch
     mutex_lock(&pe->shm_lock);
     
@@ -578,6 +585,7 @@ void handle_op_procfs_create_file(portal_region *mem_region)
 
     mutex_init(&pe->shm_lock); // Now this is safe
     pe->name = kstrdup(entry_name, GFP_KERNEL);
+    pe->mmap_phys_addr = req->mmap_phys_addr;
     pe->python_release = req->fops.release;
 
     // Evaluate if we should fall back to the default mmap proxy

--- a/src/portal/portal_sysfs.c
+++ b/src/portal/portal_sysfs.c
@@ -69,6 +69,7 @@ struct igloo_sysfs_ops {
 struct portal_sysfs_create_req {
     char path[PROCFS_MAX_PATH];
     struct igloo_sysfs_ops ops; // Ops passed from hypervisor
+    uint64_t mmap_phys_addr;
     int parent_id;
     int replace;
     umode_t mode; 

--- a/src/portal/portal_types.h
+++ b/src/portal/portal_types.h
@@ -152,6 +152,7 @@ struct portal_procfs_create_req {
     char path[PROCFS_MAX_PATH];
     struct igloo_proc_ops fops;
     uint64_t size;
+    uint64_t mmap_phys_addr;
     uint8_t support_mmap;
     int parent_id;
     umode_t mode;
@@ -166,6 +167,7 @@ struct portal_procfs_entry {
     struct proc_dir_entry *parent;
     struct file *shm_file;
     struct mutex shm_lock;
+    uint64_t mmap_phys_addr;
     void *python_release;
 };
 


### PR DESCRIPTION
This commit updates the igloo_driver to support direct physical memory mapping for pseudofiles. This is a critical part of the new native QEMU mmap feature.

Key changes:
- Adds a mmap_phys_addr field to the portal request structures (portal_procfs_create_req, portal_devfs_create_req, etc.) and their corresponding internal tracking structs.
- Implements new mmap handlers in portal_procfs.c, portal_devfs.c, and portal_anon.c that check for this physical address.
- If a valid physical address is provided by Penguin, the driver now uses remap_pfn_range with pgprot_noncached to map the QEMU-managed memory directly into the guest process's address space.