### PR TITLE
feat(driver): add signal interception and shaping hooks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -76,6 +76,29 @@ done
 
 echo "Building modules for kernel versions: ${VERSIONS}, targets: ${TARGETS}..."
 
+kernel_devel_cache_complete() {
+    local base_dir=$1
+    local package=$2
+    local target
+    local version
+    local manifest="${base_dir}/.kernel_devel_pkg_configs"
+
+    [ -f "$base_dir/.kernel_devel_pkg_hash" ] || return 1
+    if [ ! -f "$manifest" ]; then
+        tar -tzf "$package" | sed -n 's#^\./\([^/]*\)/\.config$#\1#p' > "$manifest"
+    fi
+
+    for version in $VERSIONS; do
+        for target in $TARGETS; do
+            if grep -Fxq "${target}.${version}" "$manifest"; then
+                [ -f "$base_dir/${target}.${version}/.config" ] || return 1
+            fi
+        done
+    done
+
+    return 0
+}
+
 # Extract kernel-devel package if not using custom path
 if [ -z "$KERNEL_DEVEL_PATH" ]; then
     PKG=local_packages/kernel-devel-all.tar.gz
@@ -90,11 +113,12 @@ if [ -z "$KERNEL_DEVEL_PATH" ]; then
             OLD_HASH="$(cat "$HASHFILE")" || OLD_HASH=""
         fi
 
-        if [ "$PKG_HASH" = "$OLD_HASH" ] && [ -n "$(ls -A cache/kernel-devel-extract 2>/dev/null)" ]; then
+        if [ "$PKG_HASH" = "$OLD_HASH" ] && kernel_devel_cache_complete cache/kernel-devel-extract "$PKG"; then
             echo "Using cached kernel-devel-extract (hash unchanged)"
         else
             echo "Extracting kernel-devel package (hash changed or no cache)"
             rm -rf cache/kernel-devel-extract/*
+            rm -f cache/kernel-devel-extract/.kernel_devel_pkg_configs
             pigz -dc "$PKG" | tar -xf - -C cache/kernel-devel-extract
             # Update hash atomically
             printf '%s' "$PKG_HASH" > "${HASHFILE}.tmp" && mv "${HASHFILE}.tmp" "$HASHFILE"
@@ -106,7 +130,11 @@ if [ -z "$KERNEL_DEVEL_PATH" ]; then
         exit 1
     fi
 else
-    KERNEL_DEVEL_MOUNT_DIR="$KERNEL_DEVEL_PATH"
+    if [[ "$KERNEL_DEVEL_PATH" = /* ]]; then
+        KERNEL_DEVEL_MOUNT_DIR="$KERNEL_DEVEL_PATH"
+    else
+        KERNEL_DEVEL_MOUNT_DIR="$(pwd)/$KERNEL_DEVEL_PATH"
+    fi
 fi
 
 # Set build output directory in cache & initialize subfolders

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@ PORTAL_OBJS := $(patsubst $(src)/%.c,%.o,$(PORTAL_SRCS))
 
 igloo-objs += igloo_hc.o hooks/syscalls_hc.o hooks/ioctl_hc.o \
         hooks/sock_hc.o hooks/uname_hc.o hooks/block_mounts.o \
-		hooks/igloo_open.o \
+		hooks/igloo_open.o hooks/signal_hc.o \
 		hyperfs/hyperfs.o \
 		netdevs/igloonet.o \
 		$(PORTAL_OBJS)

--- a/src/args.h
+++ b/src/args.h
@@ -4,6 +4,13 @@
 #if defined(__mips__)
 #include <asm/syscall.h>
 
+static inline unsigned long regs_get_argument(struct pt_regs *regs, unsigned int n)
+{
+    if (n < 4)
+        return regs->regs[4 + n];
+    return 0;
+}
+
 static inline bool local_mips_syscall_is_indirect(struct task_struct *task,
 					    struct pt_regs *regs)
 {
@@ -61,6 +68,16 @@ static inline void syscall_set_argument(struct task_struct *task,
 }
 
 #elif defined(__arm__)
+static inline unsigned long regs_get_argument(struct pt_regs *regs, unsigned int n)
+{
+    switch (n) {
+    case 0: return regs->ARM_r0;
+    case 1: return regs->ARM_r1;
+    case 2: return regs->ARM_r2;
+    case 3: return regs->ARM_r3;
+    }
+    return 0;
+}
 static inline void syscall_set_argument(struct task_struct *task,
 					 struct pt_regs *regs,
 					 int i, unsigned long arg)
@@ -114,6 +131,18 @@ static inline void syscall_set_argument(struct task_struct *task,
 }
 
 #elif defined(__x86_64__)
+static inline unsigned long regs_get_argument(struct pt_regs *regs, unsigned int n)
+{
+    switch (n) {
+    case 0: return regs->di;
+    case 1: return regs->si;
+    case 2: return regs->dx;
+    case 3: return regs->cx;
+    case 4: return regs->r8;
+    case 5: return regs->r9;
+    }
+    return 0;
+}
 static inline void syscall_set_argument(struct task_struct *task,
                                        struct pt_regs *regs,
                                        int i, unsigned long arg)

--- a/src/args.h
+++ b/src/args.h
@@ -102,6 +102,13 @@ static inline void syscall_set_argument(struct task_struct *task,
 }
 
 #elif defined(__aarch64__)
+static inline unsigned long regs_get_argument(struct pt_regs *regs, unsigned int n)
+{
+    if (n < 6)
+        return regs->regs[n];
+    return 0;
+}
+
 static inline void syscall_set_argument(struct task_struct *task,
                                        struct pt_regs *regs,
                                        int i, unsigned long arg)
@@ -172,6 +179,19 @@ static inline void syscall_set_argument(struct task_struct *task,
 }
 
 #elif defined(__i386__)
+static inline unsigned long regs_get_argument(struct pt_regs *regs, unsigned int n)
+{
+    switch (n) {
+    case 0: return regs->bx;
+    case 1: return regs->cx;
+    case 2: return regs->dx;
+    case 3: return regs->si;
+    case 4: return regs->di;
+    case 5: return regs->bp;
+    }
+    return 0;
+}
+
 static inline void syscall_set_argument(struct task_struct *task,
                                        struct pt_regs *regs,
                                        int i, unsigned long arg)
@@ -201,6 +221,13 @@ static inline void syscall_set_argument(struct task_struct *task,
 }
 
 #elif defined(__loongarch__)
+static inline unsigned long regs_get_argument(struct pt_regs *regs, unsigned int n)
+{
+    if (n < 6)
+        return regs->regs[4 + n];
+    return 0;
+}
+
 static inline void syscall_set_argument(struct task_struct *task,
                                        struct pt_regs *regs,
                                        int i, unsigned long arg)
@@ -230,6 +257,19 @@ static inline void syscall_set_argument(struct task_struct *task,
 }
 
 #elif defined(__riscv)
+static inline unsigned long regs_get_argument(struct pt_regs *regs, unsigned int n)
+{
+    switch (n) {
+    case 0: return regs->a0;
+    case 1: return regs->a1;
+    case 2: return regs->a2;
+    case 3: return regs->a3;
+    case 4: return regs->a4;
+    case 5: return regs->a5;
+    }
+    return 0;
+}
+
 static inline void syscall_set_argument(struct task_struct *task,
                                        struct pt_regs *regs,
                                        int i, unsigned long arg)
@@ -259,6 +299,13 @@ static inline void syscall_set_argument(struct task_struct *task,
 }
 
 #elif defined(__powerpc__) || defined(__PPC__)
+static inline unsigned long regs_get_argument(struct pt_regs *regs, unsigned int n)
+{
+    if (n < 6)
+        return regs->gpr[3 + n];
+    return 0;
+}
+
 static inline void syscall_set_argument(struct task_struct *task,
                                        struct pt_regs *regs,
                                        int i, unsigned long arg)

--- a/src/hooks/signal_hc.c
+++ b/src/hooks/signal_hc.c
@@ -1,0 +1,164 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/kprobes.h>
+#include <linux/sched.h>
+#include <linux/slab.h>
+#include "hypercall.h"
+#include "igloo.h"
+#include "signal_hc.h"
+#include "portal/portal.h"
+#include "portal/portal_internal.h"
+#include "args.h"
+
+/* Global hash table for signal hooks */
+static struct hlist_head signal_hook_table[64];
+static struct hlist_head any_signal_hooks;
+static DEFINE_SPINLOCK(signal_hook_lock);
+static atomic_t global_signal_hook_count = ATOMIC_INIT(0);
+
+static struct kprobe signal_kp;
+
+static void do_signal_hyp(struct signal_event *event) {
+    igloo_portal(IGLOO_HYP_SIGNAL_DELIVER, (unsigned long)event, 0);
+}
+
+static bool hook_matches_signal(struct kernel_signal_hook *hook, int sig, struct task_struct *t) {
+    if (hook->hook.sig != 0 && hook->hook.sig != sig)
+        return false;
+    
+    if (hook->hook.pid_filter_enabled && hook->hook.filter_pid != task_tgid_vnr(t))
+        return false;
+    
+    if (hook->hook.comm_filter_enabled && strcmp(hook->hook.comm_filter, t->comm) != 0)
+        return false;
+    
+    return true;
+}
+
+static int handler_pre(struct kprobe *p, struct pt_regs *regs) {
+    int sig;
+    struct task_struct *t;
+    struct kernel_signal_hook *hook;
+    struct signal_event event;
+    bool drop = false;
+    bool needs_hyp = false;
+
+    if (atomic_read(&global_signal_hook_count) == 0)
+        return 0;
+
+    /* sig is first arg, t is third arg in __send_signal(int sig, struct siginfo *info, struct task_struct *t...) */
+    sig = (int)regs_get_argument(regs, 0);
+    t = (struct task_struct *)regs_get_argument(regs, 2);
+
+    if (!t) return 0;
+
+    rcu_read_lock();
+    
+    /* Check specific signal hooks */
+    hash_for_each_possible_rcu(signal_hook_table, hook, hlist, sig) {
+        if (hook->hook.enabled && hook_matches_signal(hook, sig, t)) {
+            needs_hyp = true;
+            break;
+        }
+    }
+
+    /* Check "any" (*) signal hooks */
+    if (!needs_hyp) {
+        hlist_for_each_entry_rcu(hook, &any_signal_hooks, hlist) {
+            if (hook->hook.enabled && hook_matches_signal(hook, sig, t)) {
+                needs_hyp = true;
+                break;
+            }
+        }
+    }
+
+    if (needs_hyp) {
+        memset(&event, 0, sizeof(event));
+        event.sig = sig;
+        event.hook = &hook->hook;
+        event.task = t;
+        event.regs = task_pt_regs(t);
+        if (event.regs) {
+            event.pc = instruction_pointer(event.regs);
+        }
+        event.pid = task_tgid_vnr(t);
+        strncpy(event.comm, t->comm, TASK_COMM_LEN);
+        event.drop = false;
+
+        do_signal_hyp(&event);
+
+        if (event.drop) {
+            drop = true;
+        }
+    }
+    rcu_read_unlock();
+
+    if (drop) {
+        /* Set sig to 0 to effectively silence it in __send_signal */
+        syscall_set_argument(current, regs, 0, 0);
+    }
+
+    return 0;
+}
+
+int signal_hc_init(void) {
+    int ret;
+    hash_init(signal_hook_table);
+    INIT_HLIST_HEAD(&any_signal_hooks);
+
+    signal_kp.symbol_name = "__send_signal";
+    signal_kp.pre_handler = handler_pre;
+
+    ret = register_kprobe(&signal_kp);
+    if (ret < 0) {
+        printk(KERN_ERR "IGLOO: Failed to register kprobe on __send_signal: %d\n", ret);
+        return 0;
+    }
+
+    return 0;
+}
+
+void handle_op_register_signal_hook(portal_region *mem_region) {
+    struct signal_hook *h = (struct signal_hook *)PORTAL_DATA(mem_region);
+    struct kernel_signal_hook *kh;
+
+    kh = kzalloc(sizeof(*kh), GFP_KERNEL);
+    if (!kh) {
+        mem_region->header.op = HYPER_RESP_WRITE_FAIL;
+        return;
+    }
+
+    memcpy(&kh->hook, h, sizeof(*h));
+    kh->in_use = true;
+
+    spin_lock(&signal_hook_lock);
+    if (kh->hook.sig == 0) {
+        hlist_add_head_rcu(&kh->hlist, &any_signal_hooks);
+    } else {
+        hash_add_rcu(signal_hook_table, &kh->hlist, kh->hook.sig);
+    }
+    atomic_inc(&global_signal_hook_count);
+    spin_unlock(&signal_hook_lock);
+
+    mem_region->header.addr = (unsigned long)kh;
+    mem_region->header.op = HYPER_RESP_WRITE_OK;
+}
+
+void handle_op_unregister_signal_hook(portal_region *mem_region) {
+    struct kernel_signal_hook *kh = (struct kernel_signal_hook *)mem_region->header.addr;
+
+    if (!kh || !kh->in_use) {
+        mem_region->header.op = HYPER_RESP_WRITE_FAIL;
+        return;
+    }
+
+    spin_lock(&signal_hook_lock);
+    hash_del_rcu(&kh->hlist);
+    atomic_dec(&global_signal_hook_count);
+    kh->in_use = false;
+    spin_unlock(&signal_hook_lock);
+
+    kfree_rcu(kh, rcu);
+    mem_region->header.op = HYPER_RESP_WRITE_OK;
+}

--- a/src/hooks/signal_hc.h
+++ b/src/hooks/signal_hc.h
@@ -1,0 +1,48 @@
+#ifndef _SIGNAL_HC_H
+#define _SIGNAL_HC_H
+
+#include <linux/types.h>
+#include <linux/spinlock.h>
+#include <linux/hashtable.h>
+#include <linux/sched.h>
+#include "syscalls_hc.h"
+#include "portal/portal_types.h"
+
+#define SIGNAL_NAME_MAX_LEN 32
+
+struct signal_hook {
+    bool enabled;
+    int sig;                            /* Signal number, 0 for any */
+    
+    /* PID filtering */
+    bool pid_filter_enabled;
+    pid_t filter_pid;
+    
+    /* Process filtering */
+    bool comm_filter_enabled;
+    char comm_filter[TASK_COMM_LEN];
+};
+
+struct signal_event {
+    uint32_t sig;                      /* Signal number */
+    struct signal_hook *hook;          /* Hook pointer */
+    struct task_struct *task;          /* Target task */
+    struct pt_regs *regs;              /* Target task regs */
+    bool drop;                         /* Set to true to drop signal */
+    uint64_t pc;                       /* PC of the target task */
+    char comm[TASK_COMM_LEN];          /* Target task comm */
+    pid_t pid;                         /* Target task pid */
+};
+
+struct kernel_signal_hook {
+    struct signal_hook hook;
+    struct hlist_node hlist;
+    bool in_use;
+    struct rcu_head rcu;
+};
+
+int signal_hc_init(void);
+void handle_op_register_signal_hook(portal_region *mem_region);
+void handle_op_unregister_signal_hook(portal_region *mem_region);
+
+#endif /* _SIGNAL_HC_H */

--- a/src/igloo_hc.c
+++ b/src/igloo_hc.c
@@ -36,6 +36,7 @@ int sock_hc_init(void);
 int uname_hc_init(void);
 int block_mounts_init(void);
 int igloo_open_init(void);
+int signal_hc_init(void);
 
 /* Register probes for mmap and munmap */
 int init_module(void) {
@@ -45,6 +46,11 @@ int init_module(void) {
 
     if ((ret = syscalls_hc_init()) != 0) {
         printk(KERN_ERR "Failed to register syscalls_hc returning %d\n", ret);
+        return ret;
+    }
+
+    if ((ret = signal_hc_init()) != 0) {
+        printk(KERN_ERR "Failed to register signal_hc returning %d\n", ret);
         return ret;
     }
 

--- a/src/igloo_hypercall_consts.h
+++ b/src/igloo_hypercall_consts.h
@@ -30,6 +30,7 @@ enum igloo_hypercall_constants {
     IGLOO_HYP_SYSCALL_ENTER  = 0x1338,
     IGLOO_HYP_SYSCALL_RETURN = 0x1339,
     IGLOO_HYP_SETUP_TASK_COMM = 0x133a,
+    IGLOO_HYP_SIGNAL_DELIVER = 0x133b,
     IGLOO_HYP_OSI_TASK_SWITCH = 0x3337,
     
     /* Uprobe operations */

--- a/src/portal/portal_op_list.h
+++ b/src/portal/portal_op_list.h
@@ -21,6 +21,8 @@
     X(unregister_uprobe, UNREGISTER_UPROBE) \
     X(register_syscall_hook, REGISTER_SYSCALL_HOOK) \
     X(unregister_syscall_hook, UNREGISTER_SYSCALL_HOOK) \
+    X(register_signal_hook, REGISTER_SIGNAL_HOOK) \
+    X(unregister_signal_hook, UNREGISTER_SIGNAL_HOOK) \
     X(ffi_exec, FFI_EXEC) \
     X(kallsyms_lookup, KALLSYMS_LOOKUP) \
     X(tramp_generate, TRAMP_GENERATE) \


### PR DESCRIPTION
- Adds a kprobe on `__send_signal` to intercept signals.
- Introduces a new hypercall (IGLOO_HYP_SIGNAL_DELIVER) to notify the host.
- Implements in-kernel filtering for signals, PIDs, and process names to reduce hypervisor exits.
- Allows the host to drop signals or modify registers via the hypercall response.