### PR TITLE
Drop unused task switch hypercall constant

### DIFF
--- a/src/igloo_hypercall_consts.h
+++ b/src/igloo_hypercall_consts.h
@@ -31,7 +31,6 @@ enum igloo_hypercall_constants {
     IGLOO_HYP_SYSCALL_RETURN = 0x1339,
     IGLOO_HYP_SETUP_TASK_COMM = 0x133a,
     IGLOO_HYP_SIGNAL_DELIVER = 0x133b,
-    IGLOO_HYP_OSI_TASK_SWITCH = 0x3337,
     
     /* Uprobe operations */
     IGLOO_HYP_UPROBE_ENTER  = 0x6901,


### PR DESCRIPTION
## Summary
- Remove the unused `IGLOO_HYP_OSI_TASK_SWITCH` hypercall constant.
- Avoid advertising a stale marker value that is no longer consumed by the Python side.

## Validation
- `rg IGLOO_HYP_OSI_TASK_SWITCH` now returns no in-tree users.