### PR TITLE
sock_hc: only report releases for listening TCP sockets

### DIFF
--- a/src/hooks/sock_hc.c
+++ b/src/hooks/sock_hc.c
@@ -9,6 +9,7 @@
 #include <linux/socket.h>
 #include <linux/ipv6.h>
 #include <net/inet_sock.h>
+#include <net/tcp_states.h>
 #include "igloo.h"
 #include <linux/kallsyms.h>
 #include <linux/version.h>
@@ -91,26 +92,32 @@ void igloo_sock_release(struct socket *sock){
 		if (sk->sk_family == AF_INET) {
 			char buffer[23];
 			struct inet_sock *inet = inet_sk(sk);
-			port = ntohs(inet->inet_sport);      
-			if (port != 0){
-				__be32 ip = inet->inet_saddr;          
-				short is_stream = (sk->sk_type == SOCK_STREAM);
+			short is_stream = (sk->sk_type == SOCK_STREAM);
+			port = ntohs(inet->inet_sport);
+			// For TCP, only report listening sockets closing. Accepted and
+			// connected sockets share the listener's local port, so reporting
+			// their teardown would emit spurious release events for a service
+			// that is still listening.
+			if (port != 0 && (!is_stream || sk->sk_state == TCP_LISTEN)){
+				__be32 ip = inet->inet_saddr;
 				snprintf(buffer, sizeof(buffer), "%pI4:%u", &ip, port);
-				e = igloo_hypercall2(IGLOO_IPV4_RELEASE, (unsigned long)&buffer, (unsigned long)is_stream); 
+				e = igloo_hypercall2(IGLOO_IPV4_RELEASE, (unsigned long)&buffer, (unsigned long)is_stream);
 			}
 		}
 		else if (sk->sk_family == AF_INET6) {
 			char buffer[49];
 			struct inet_sock *inet = inet_sk(sk);
 			struct ipv6_pinfo *ipv6_s = inet6_sk(sk);
+			short is_stream = (sk->sk_type == SOCK_STREAM);
 			port = ntohs(inet->inet_sport);
 
-			if (port != 0){
+			// As above: for TCP only report listeners, not accepted/connected
+			// sockets that share the listener's local port.
+			if (port != 0 && (!is_stream || sk->sk_state == TCP_LISTEN)){
 				struct in6_addr *ip6 = &ipv6_s->saddr;
-				short is_stream = (sk->sk_type == SOCK_STREAM);
 
 				snprintf(buffer, sizeof(buffer), "[%pI6c]:%u", ip6, port);
-				
+
 				e = igloo_hypercall2(IGLOO_IPV6_RELEASE, (unsigned long)&buffer, (unsigned long)is_stream);
 			}
 		}


### PR DESCRIPTION
## Summary

`igloo_sock_release` fired a release hypercall for **any** socket release, including accepted/connected sockets that share a listener's local port. A client disconnecting from a service therefore looked like the listener itself closing — most damaging for loopback services bound to `127.0.0.1`, whose connections share the bound address.

Gate TCP releases on `sk->sk_state == TCP_LISTEN` (both IPv4 and IPv6) so only genuine listener shutdowns are reported. UDP behavior is unchanged. Adds `#include <net/tcp_states.h>` for the constant.

The hook runs before `inet_release`/`tcp_close` (it already reads a live `inet_sport`), so a listener is still in `TCP_LISTEN` at this point.

## Why

Pairs with the host-side socket lifecycle tracking in rehosting/penguin#822 (NetBinds debounce + transient labeling): without this guard, connection teardowns would be mislabeled as service closes / flaps.

## Validation
- Compiles clean against armel/4.10 kernel-devel via `./build.sh` (no warnings from `sock_hc.c`); module loads in-guest.
- Logical review of state ordering; `TCP_LISTEN`/`sk_state` are stable across 4.10 and 6.13.
- Full in-guest behavioral test pending a matched kernel+driver rebuild (see paired penguin PR).