### PR TITLE
portal_devfs: don't install cdev-only poll/write proxies on anon/sock files

### DIFF
--- a/src/portal/portal_devfs.c
+++ b/src/portal/portal_devfs.c
@@ -365,16 +365,23 @@ void igloo_convert_ops_to_fops(const struct igloo_dev_ops *ops, struct file_oper
     out->open = ops->open;
     out->read = ops->read;
     out->read_iter = ops->read_iter;
-    // Route writes through the proxy so a queued response wakes blocked pollers (issue #77).
-    out->write = igloo_devfs_proxy_write;
+    // Default to the Python-modeled write. The char-device create path swaps in
+    // igloo_devfs_proxy_write so a queued response wakes blocked pollers (issue
+    // #77); the proxy resolves its entry via inode->i_cdev, so it must NOT be
+    // installed here — anon/sock files reuse this converter and have no cdev
+    // (i_cdev == NULL), which would make every write return -ENODEV.
+    out->write = ops->write;
     out->write_iter = ops->write_iter;
     out->llseek = ops->lseek;
 
     // NEW: Route release through our writeback proxy
     out->release = igloo_devfs_proxy_release;
 
-    // Route poll through the proxy so it can poll_wait() before consulting Python (issue #77).
-    out->poll = igloo_devfs_proxy_poll;
+    // Default to the Python-modeled poll. The char-device create path swaps in
+    // igloo_devfs_proxy_poll (poll_wait() on the per-device wait queue before
+    // consulting Python, issue #77); like the write proxy it is cdev-only, so it
+    // is installed in the char path rather than this shared converter.
+    out->poll = ops->poll;
     out->unlocked_ioctl = ops->ioctl;
 #ifdef CONFIG_COMPAT
     out->compat_ioctl = ops->compat_ioctl;
@@ -738,7 +745,14 @@ void handle_op_devfs_create_device(portal_region *mem_region)
 
         pe->devt = devt;
         igloo_convert_ops_to_fops(&req->ops, &pe->fops, enable_default_mmap);
-        
+
+        // issue #77: the poll/write proxies resolve their portal_devfs_entry via
+        // inode->i_cdev, so they are only valid for char devices. Install them
+        // here (not in the shared converter) so anon/sock files, which reuse the
+        // converter with no cdev, keep their direct Python write/poll.
+        pe->fops.write = igloo_devfs_proxy_write;
+        pe->fops.poll = igloo_devfs_proxy_poll;
+
         cdev_init(&pe->cdev, &pe->fops);
         pe->cdev.owner = THIS_MODULE;
 


### PR DESCRIPTION
## Problem

The issue #77 / #78 poll & write proxies (`igloo_devfs_proxy_poll`, `igloo_devfs_proxy_write`) resolve their tracking struct with `container_of(inode->i_cdev, struct portal_devfs_entry, cdev)` — they are **char-device-only**.

#78 installed them inside the **shared** `igloo_convert_ops_to_fops()`, but that converter is also called by `portal_anon.c` (`handle_op_anonfs_create_file` / sockfs) to build fops for **anon inodes and sockets**, which have no cdev (`inode->i_cdev == NULL`). As a result `igloo_devfs_proxy_write` hits `if (!inode->i_cdev) return -ENODEV;` and **every write to an anon file or socket fails with ENODEV**.

This surfaced as the `anonfs` unit tests (`anonfs_test_pass/_counter/_socket`) going red on **every arch** the moment a tree pins driver **0.0.81** (e.g. penguin #845, and it will hit anyone bumping past 0.0.80). `echo 5 > /tmp/anon_counter` fails, the `set -eux` script aborts before `PASS`. Pre-0.0.81 the converter set `out->write = ops->write` directly, so anon/sock writes worked.

## Fix

Keep the shared converter on the direct Python-modeled `write`/`poll`, and install the cdev-only proxies **only in the char-device create path** (`handle_op_devfs_create_device`), where the `cdev` and `poll_wq` actually exist. The #77 blocking-poll + wake-on-write behavior for char devices is unchanged. Block devices call `python_write` directly via `queue_rq`, so they don't need the proxy either.

Net diff: one file, `src/portal/portal_devfs.c`.

## Follow-up
Once merged and 0.0.82 is released, penguin #845 will be re-pinned 0.0.81 → 0.0.82 (restores anonfs green there).