### PR TITLE
portal/devfs: share a dynamic char-major block instead of one major per device

### DIFF
--- a/src/portal/portal_devfs.c
+++ b/src/portal/portal_devfs.c
@@ -515,6 +515,50 @@ static void ensure_portal_class(void)
     }
 }
 
+/*
+ * Shared dynamic char-device region.
+ *
+ * A device registered with major < 0 wants a kernel-assigned device number.
+ * The naive approach — alloc_chrdev_region() per device — burns one whole
+ * MAJOR each time, and the kernel only has ~234 free majors. Firmware that
+ * models many /dev nodes (e.g. RouterOS opens /dev/log%d and we enumerate
+ * /dev/log0..255) exhausted that pool, so every device past the limit failed
+ * to register with "kernel returned 0".
+ *
+ * Instead, reserve majors in blocks and hand out one MINOR per device. A
+ * single major then covers IGLOO_DYN_MINORS devices, and we allocate a fresh
+ * block only when the current one fills, lifting the effective limit from
+ * ~234 devices to ~234 * IGLOO_DYN_MINORS.
+ */
+#define IGLOO_DYN_MINORS 256
+static DEFINE_MUTEX(igloo_dyn_lock);
+static dev_t igloo_dyn_base;          /* MKDEV(major, 0) of the current block */
+static unsigned int igloo_dyn_count;  /* minors reserved in the current block */
+static unsigned int igloo_dyn_used;   /* minors handed out from the block     */
+
+static int igloo_alloc_dynamic_devt(dev_t *out)
+{
+    int ret = 0;
+
+    mutex_lock(&igloo_dyn_lock);
+    if (igloo_dyn_used >= igloo_dyn_count) {
+        dev_t base;
+
+        ret = alloc_chrdev_region(&base, 0, IGLOO_DYN_MINORS, "igloo_devfs");
+        if (ret < 0) {
+            mutex_unlock(&igloo_dyn_lock);
+            return ret;
+        }
+        igloo_dyn_base = base;
+        igloo_dyn_count = IGLOO_DYN_MINORS;
+        igloo_dyn_used = 0;
+    }
+    *out = MKDEV(MAJOR(igloo_dyn_base), MINOR(igloo_dyn_base) + igloo_dyn_used);
+    igloo_dyn_used++;
+    mutex_unlock(&igloo_dyn_lock);
+    return 0;
+}
+
 /* * -------------------------------------------------------------------------
  * Directory Logic (New)
  * -------------------------------------------------------------------------
@@ -734,7 +778,9 @@ void handle_op_devfs_create_device(portal_region *mem_region)
         bool dynamic_chrdev_region = req->major < 0;
 
         if (dynamic_chrdev_region) {
-            ret = alloc_chrdev_region(&devt, 0, 1, final_device_name);
+            // Hand out a MINOR from a shared major block rather than burning a
+            // whole major per device (see igloo_alloc_dynamic_devt).
+            ret = igloo_alloc_dynamic_devt(&devt);
         } else {
             devt = MKDEV(req->major, req->minor);
             if (req->replace) unregister_chrdev_region(devt, 1);
@@ -757,7 +803,9 @@ void handle_op_devfs_create_device(portal_region *mem_region)
         pe->cdev.owner = THIS_MODULE;
 
         if (cdev_add(&pe->cdev, devt, 1)) {
-            unregister_chrdev_region(devt, 1);
+            // A shared-region minor belongs to a larger reserved block; only
+            // standalone (static-major) registrations own their region.
+            if (!dynamic_chrdev_region) unregister_chrdev_region(devt, 1);
             goto fail_alloc;
         }
 
@@ -774,7 +822,7 @@ void handle_op_devfs_create_device(portal_region *mem_region)
             list_del(&pe->list);
             spin_unlock(&devfs_entry_lock);
             cdev_del(&pe->cdev);
-            unregister_chrdev_region(devt, 1);
+            if (!dynamic_chrdev_region) unregister_chrdev_region(devt, 1);
             goto fail_alloc;
         }
     }


### PR DESCRIPTION
## Problem

Devices registered with `major < 0` each call `alloc_chrdev_region()`, which allocates **one whole char-device MAJOR per device**. The kernel only has ~234 free majors, so firmware modeling many `/dev` nodes exhausts the pool.

Concretely on **RouterOS6 (armel)**: nova opens `/dev/log%d` in a busy loop, so the config enumerates `/dev/log0..255` (+ other nodes, ~339 total). Registrations past the cap fail with `HYPER_RESP_WRITE_FAIL` → the plugin logs `Failed to register devfs device 'logNNN' (kernel returned 0)` **×105**. The guest still boots, but those `/dev/logN` nodes go unmodeled → `ENOENT` open-spin → CPU drain, defeating the very reason they're modeled.

## Fix

`igloo_alloc_dynamic_devt()`: reserve majors in **blocks of `IGLOO_DYN_MINORS` (256)** and hand out one MINOR per device, allocating a fresh block only when the current fills. Effective cap goes from ~234 devices to ~234×256. The `cdev_add()`/`device_create()` failure paths only `unregister_chrdev_region()` for static-major registrations (a shared-block minor doesn't own its region).

## On the prior revert

A prior shared-major attempt (driver 0.0.75, `6fff830`) was reverted (`a979a09`, 0.0.76) for an **unrelated mipsel `do_ade` unaligned-access crash** — never documented at the time. I reproduced that crash on a period-accurate image and traced it to a **separate unaligned-access bug in the era's driver/qemu, since fixed on the current base** — *not* to major-sharing. Evidence: 0.0.75's exact allocator ported onto the current base boots mipsel clean.

## Validation

- **Real target** — armel RouterOS6: **105 → 0** devfs registration failures; boots to READY, verifier **all-pass**.
- **MIPS matrix** — `{mipsel, mipseb, mips64el, mips64eb} × {4.10, 6.13}`: **8/8 clean boots, 0 `do_ade`** (incl. big-endian, the worst case for unaligned access).
- **Stress** — 300-device `/dev` flood on mipsel: all register across the 256-minor block rollover, no crash (vs 93 failures per-device).

## Follow-up

A regression guard (mipsel + dynamic-devfs flood boot test) will be added in penguin's `basic_target` CI as a tripwire once this is released and pinned.