### PR TITLE
portal_mtd: set writebufsize so UBI can attach to hyperfile MTD

### DIFF
--- a/src/portal/portal_mtd.c
+++ b/src/portal/portal_mtd.c
@@ -199,6 +199,17 @@ void handle_op_mtd_create(portal_region *mem_region)
     mtd->size = req_total_size;
     mtd->erasesize = req_erasesize;
     mtd->writesize = req_writesize;
+    /*
+     * UBI validates the write-buffer size (max_write_size): it must be
+     * >= min_io_size (writesize), a multiple of it, and a power of 2
+     * (see ubi_attach_mtd_dev() in drivers/mtd/ubi/build.c). We previously
+     * left writebufsize at 0, so attaching UBI to one of these devices failed
+     * with "ubi_attach_mtd_dev: bad write buffer size 0 for N min. I/O unit".
+     * Setting it to the write (page) size lets UBI/UBIFS attach to
+     * hyperfile-backed MTD partitions, which vendor firmware relies on for
+     * UBI-mounted nvram/config partitions.
+     */
+    mtd->writebufsize = req_writesize;
     mtd->oobsize = req->is_nand ? req->oob_size : 0;
     mtd->owner = THIS_MODULE;
     mtd->priv = entry;


### PR DESCRIPTION
## Problem

`handle_op_mtd_create()` in `src/portal/portal_mtd.c` sets `mtd->size`,
`mtd->erasesize`, `mtd->writesize`, and `mtd->oobsize`, but leaves
`mtd->writebufsize` at its zero-initialized value.

UBI validates the write-buffer size when attaching a device
(`ubi_attach_mtd_dev()` in `drivers/mtd/ubi/build.c`): `max_write_size` must be
`>= min_io_size` (writesize), a multiple of it, and a power of 2. With
`writebufsize == 0`, attach fails immediately:

```
ubi0 error: ubi_attach_mtd_dev: bad write buffer size 0 for 2048 min. I/O unit
```

So `ubiattach` + `mount -t ubifs` cannot succeed on any portal/hyperfile-backed
MTD device, even with correct geometry.

## Fix

Set `mtd->writebufsize = req_writesize;` (the page/write size), which satisfies
UBI's requirement. This lets UBI and UBIFS attach to hyperfile-backed MTD
partitions — needed to model firmware that stores nvram/config on a UBI-mounted
MTD partition.

## Testing

Validated end-to-end against a kernel built with `CONFIG_MTD_UBI` +
`CONFIG_UBIFS_FS`: a NAND MTD device (128 KiB PEB / 2 KiB page) backed by a
`mkfs.ubifs`+`ubinize` image. Before: attach failed with the "bad write buffer
size 0" error above. After: `ubiattach` succeeds, UBI scans and attaches
(`attached mtd0 ... size 16 MiB`), and the guest mounts the UBIFS volume
(`UBIFS: mounted UBI device 0, volume 0`), reading its contents through the
genuine UBIFS → UBI → MTD path.