### PR TITLE
hyperfs: name the anonymous enum so the docs build survives Doxygen 1.10

### DIFF
--- a/src/hyperfs/hyperfs_consts.h
+++ b/src/hyperfs/hyperfs_consts.h
@@ -8,6 +8,13 @@ enum hyperfs_file_ops {
     HYP_READ, HYP_WRITE, HYP_IOCTL, HYP_GETATTR
 };
 
-enum { HYPERFILE_PATH_MAX = 1024 };
+/* Named, not anonymous, deliberately: Doxygen 1.9.8/1.10 (the version on the
+ * docs CI runner) emits an anonymous enum with an empty <name>, which Breathe
+ * turns into an empty C declaration and Sphinx rejects with "Invalid C
+ * declaration: Expected identifier in nested name. [error at 0]" -- fatal under
+ * the docs build's -W. Doxygen 1.9.1 and 1.17 instead emit a synthetic "@N"
+ * name and build fine, so this only breaks on some versions. A real tag is
+ * stable across all of them. */
+enum hyperfs_limits { HYPERFILE_PATH_MAX = 1024 };
 
 #define HYP_RETRY 0xdeadbeef


### PR DESCRIPTION
## Problem

The **Docs** workflow has failed on every push to `main` since it landed (e.g. the run for #95, and the 2026-07-17 run before it):

```
docs/api/hyperfs_api.md:8: WARNING: Invalid C declaration: Expected identifier in nested name. [error at 0]
build finished with problems, 1 warning (with warnings treated as errors).
```

`deploy_static` is skipped as a result, so **the published docs have never actually updated** from CI.

## Cause

`src/hyperfs/hyperfs_consts.h` had:

```c
enum { HYPERFILE_PATH_MAX = 1024 };
```

Doxygen's XML for an *anonymous* enum is version-dependent:

| Doxygen | `<name>` emitted | Sphinx result |
|---|---|---|
| 1.9.1 | `@7` | builds |
| **1.9.8 / 1.10** | *(empty)* | **fails at col 0** |
| 1.17 | `@7` | builds |

Breathe turns the empty name into an empty C declaration, and the Sphinx C domain rejects it — fatal under the docs build's `-W`.

1.9.8 is exactly what `apt-get install doxygen` yields on `ubuntu-latest` (noble: `1.9.8+ds-2ubuntu0.1`). So this broke with **no docs and no hyperfs change** — the runner image moved to 24.04 underneath the workflow, invalidating the "the build is currently warning-clean" note in `docs.yaml`.

## Fix

Give the enum a real tag. Stable across all three Doxygen versions.

No functional change: the enumerator keeps its value (and gains a named type in the ISF instead of an anonymous one). `HYPERFILE_PATH_MAX` currently has no in-tree users.

## Verification

Reproduced locally against **Doxygen 1.10.0 + Sphinx 9.1.0** (pinned via `nix shell github:NixOS/nixpkgs/nixos-24.11#doxygen`):

- before: `WARNING: Invalid C declaration ... [error at 0]` → `build finished with problems`
- after: `build succeeded.`

Also confirmed the failure does *not* reproduce on Doxygen 1.9.1 or 1.17.0, which is why it looked clean when written.

## Possible follow-up (not in this PR)

`docs/requirements.txt` is unpinned and the Doxygen version is whatever the runner image ships, so the docs build can rot again from an upstream bump alone. Pinning both, or dropping `-W` in favour of an explicit warning allowlist, would make it deterministic. Happy to do either if wanted.