### PR TITLE
docs: fix the anonymous-enum failure breaking the Docs workflow, and pin the build inputs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,7 +35,14 @@ concurrency:
 
 jobs:
   build_docs:
-    runs-on: ubuntu-latest
+    # Pinned to 24.04, NOT ubuntu-latest: Doxygen comes from apt, so the runner
+    # image decides its version, and Doxygen's XML for anonymous aggregates is
+    # not stable across releases. 1.9.1 emitted an "@N" placeholder name that
+    # Breathe skipped; 1.9.8 (what 24.04 ships) emits an empty <name>, which
+    # Sphinx's C domain cannot parse -- that is what broke this build. Combined
+    # with -W below, letting ubuntu-latest roll means CI can go red with no
+    # change on our side. Bump deliberately, and re-run the docs build when you do.
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -46,6 +53,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y doxygen
+          doxygen --version
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -59,7 +67,9 @@ jobs:
         run: |
           # conf.py runs Doxygen itself, so a bare sphinx-build is
           # self-contained. -W turns warnings into errors to keep the docs
-          # honest (the build is currently warning-clean).
+          # honest. The build is warning-clean as of this commit -- and stays
+          # that way only because both inputs are pinned: the Python side by
+          # docs/requirements.txt, the Doxygen side by the runs-on image above.
           sphinx-build -b html -W --keep-going docs docs/_build/html
           tar -czvf docs.tar.gz -C docs/_build/html .
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,11 +3,58 @@
 #   python3 -m venv .venv && . .venv/bin/activate
 #   pip install -r docs/requirements.txt
 #   sphinx-build docs/ docs/_build/html   # (needs `doxygen` on PATH too)
-sphinx
-myst-parser
-furo
-breathe
-sphinx-copybutton
-sphinxemoji
-sphinx-notfound-page
-linkify-it-py
+#
+# Fully pinned, including transitive deps. The docs build runs with -W
+# (warnings-as-errors), so ANY upstream release can turn CI red with no change
+# on our side -- docutils and myst-parser in particular. Resolved and verified
+# warning-clean on Python 3.12 (the version docs.yaml installs).
+#
+# To upgrade: install unpinned into a fresh 3.12 venv, run
+#   sphinx-build -b html -W --keep-going docs docs/_build/html
+# and if it is clean, paste `pip freeze` back here.
+#
+# NOTE: Doxygen is NOT pinned here -- it comes from apt in docs.yaml. The runner
+# image is pinned to ubuntu-24.04 there for the same reason; see that comment.
+
+# -- Direct dependencies -----------------------------------------------------
+sphinx==9.1.0
+myst-parser==5.1.0
+furo==2025.12.19
+breathe==4.36.0
+sphinx-copybutton==0.5.2
+sphinxemoji==0.3.2
+sphinx-notfound-page==1.1.0
+linkify-it-py==2.1.0
+
+# -- Transitive dependencies (pinned for reproducibility) --------------------
+accessible-pygments==0.0.5
+alabaster==1.0.0
+babel==2.18.0
+beautifulsoup4==4.15.0
+certifi==2026.7.22
+charset-normalizer==3.4.9
+docutils==0.22.4
+idna==3.18
+imagesize==2.0.0
+jinja2==3.1.6
+markdown-it-py==4.2.0
+markupsafe==3.0.3
+mdit-py-plugins==0.6.1
+mdurl==0.1.2
+packaging==26.3
+pygments==2.20.0
+pyyaml==6.0.3
+requests==2.34.2
+roman-numerals==4.1.0
+snowballstemmer==3.1.1
+soupsieve==2.9.2
+sphinx-basic-ng==1.0.0b2
+sphinxcontrib-applehelp==2.0.0
+sphinxcontrib-devhelp==2.0.0
+sphinxcontrib-htmlhelp==2.1.0
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==2.0.0
+sphinxcontrib-serializinghtml==2.0.0
+typing-extensions==4.16.0
+uc-micro-py==2.0.0
+urllib3==2.7.0

--- a/src/hyperfs/hyperfs_consts.h
+++ b/src/hyperfs/hyperfs_consts.h
@@ -8,6 +8,11 @@ enum hyperfs_file_ops {
     HYP_READ, HYP_WRITE, HYP_IOCTL, HYP_GETATTR
 };
 
-enum { HYPERFILE_PATH_MAX = 1024 };
+/* Named rather than anonymous: Doxygen >= 1.9.8 emits an anonymous enum with an
+ * empty <name>, and Breathe hands that empty string to Sphinx's C domain, which
+ * fails to parse it ("Invalid C declaration ... [error at 0]"). Older Doxygen
+ * emitted an "@N" placeholder that Breathe skipped, which is why the docs build
+ * was clean locally and red in CI. */
+enum hyperfs_limits { HYPERFILE_PATH_MAX = 1024 };
 
 #define HYP_RETRY 0xdeadbeef


### PR DESCRIPTION
Gets the **Docs** workflow green on `main`, and pins the two inputs that decide whether it stays green.

## The failure

The Docs workflow has never passed — both runs in recent history failed (`29614125347`, `31520148466`). The latest run's entire failure is one line:

```
docs/api/hyperfs_api.md:8: WARNING: Invalid C declaration: Expected identifier in nested name. [error at 0]
build finished with problems, 1 warning (with warnings treated as errors).
```

`docs/api/hyperfs_api.md:8` is the ` ```{doxygenfile} hyperfs_consts.h ` directive, so the unparseable declaration is in the header, not the Markdown.

## Root cause

`src/hyperfs/hyperfs_consts.h` had an anonymous enum:

```c
enum { HYPERFILE_PATH_MAX = 1024 };
```

Doxygen's XML for an anonymous aggregate is **not stable across releases**:

| Doxygen | XML `<name>` for that enum | Sphinx build |
|---|---|---|
| 1.9.1 | `@7` — a placeholder Breathe recognises and skips | clean |
| 1.9.8 (ships on `ubuntu-24.04`) | *empty* | **fails** |

With 1.9.8, Breathe hands Sphinx's C domain an **empty string** as a declaration and the parser fails at offset 0 — which is exactly the `[error at 0]` with a blank caret line in the log.

That version split also explains the `docs.yaml` comment claiming the build was warning-clean: it was, against an older local Doxygen. This is not a regression from `992192d` (`do_exit` kprobe); that commit just touched `src/**` and re-triggered the path filter.

## What changed

1. **`src/hyperfs/hyperfs_consts.h`** — name the enum (`enum hyperfs_limits`). Well-formed for every Doxygen version, and better C API docs; `HYPERFILE_PATH_MAX` now actually renders on the API page instead of exploding.
2. **`docs/requirements.txt`** — pinned fully, direct *and* transitive. The build runs `-W`, so an upstream release turns CI red with no change on our side (`docutils` and `myst-parser` are the usual offenders). Header documents how to bump deliberately.
3. **`.github/workflows/docs.yaml`** — `runs-on: ubuntu-latest` → `ubuntu-24.04`. Doxygen comes from `apt`, so the runner image was silently choosing its version — that is the unpinned dependency that actually caused this failure, and pinning only the Python side would not have prevented it. Also echoes `doxygen --version` so the next failure log says which version produced the XML.

## Verification

Reproduced and fixed locally rather than pushing speculatively — note this workflow only triggers on pushes to `main` and `workflow_dispatch`, so a PR branch does **not** exercise it.

- Built `origin/main` with Python 3.12 + unpinned deps (resolved to sphinx 9.1.0 / breathe 4.36.0 / myst-parser 5.1.0, matching the failing run's `myst v5.1.0`) and local Doxygen 1.9.1 → **passed**, i.e. the Python deps were not the trigger.
- Regenerated the XML with Doxygen 1.9.8 from an `ubuntu:24.04` container, same Sphinx → reproduced the failure **byte-for-byte**.
- Built this branch in a fresh 3.12 venv installed from the pinned `docs/requirements.txt`, against Doxygen 1.9.8 XML, with `sphinx-build -b html -W --keep-going` → **build succeeded, zero warnings, exit 0**.

I also checked the other anonymous aggregates in `src/` (`portal_procfs.h`, `portal_types.h`, `hyperfs.c`) — all are either nested inside a named parent or absorbed by `TYPEDEF_HIDES_STRUCT`, and Breathe handles those. The build is clean with this one source change, so this should not need a second round trip.

## Considered and rejected

- **`EXCLUDE_SYMBOLS = X @*` in the Doxyfile** (tooling-only, source untouched). Verified this also goes green, but measured its cost: `HYPERFILE_PATH_MAX` disappears from the docs and `proc_dir_entry` drops from 29 to 27 documented members (its two anonymous unions). It would also hide future anonymous members silently.
- **Dropping `-W`.** Green immediately, but it makes the docs build near-worthless as a signal. Note Penguin's docs build (`pyplugins/docgen/doc_generator.py`) does not use `-W` and does not pin its deps — so this PR is deliberately *stricter* than Penguin rather than consistent with it. These docs are a small static build where warning-clean is achievable and worth keeping.

## Not covered

`deploy_static` has never run, so the Pages + `docs`-branch publish half is still unproven. Expect a possible second round of failures there once `build_docs` goes green; `docs.yaml` already carries comments anticipating the stale-artifact problem.