### PR TITLE
ci: pin the kernel-devel source, and record the pairing in the release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,11 @@ on:
     tags:
       - 'dev_*'
   workflow_dispatch:
+    inputs:
+      linux_builder_version:
+        description: "linux_builder release to build against (overrides the LINUX_BUILDER_VERSION pin below)"
+        type: string
+        default: ""
 
 env:
   REGISTRY: ${{ secrets.REHOSTING_ARC_REGISTRY || 'harbor.harbor.svc.cluster.local' }}
@@ -13,6 +18,18 @@ env:
   CACHE: ${{ secrets.REHOSTING_ARC_REGISTRY && format('{0}/proxy', secrets.REHOSTING_ARC_REGISTRY) || 'docker.io' }}
   TARGET: ${{ secrets.REHOSTING_ARC_REGISTRY || 'harbor.harbor.svc.cluster.local/external' }}
   EXTERNAL_REGISTRY_PASS: 'PctyVGasz15Pn9M0yA9yMNwOawFaXnk3Tl4N'
+
+  # The linux_builder release whose kernel-devel these modules are compiled
+  # against. An EXPLICIT PIN, deliberately -- this used to be
+  # `releases/latest/download/...`, a floating reference.
+  #
+  # A .ko is only loadable by the exact kernel build it was compiled against,
+  # so with a floating reference the modules in any given igloo_driver release
+  # silently depended on whatever linux_builder had published most recently,
+  # and nothing recorded which one that was. Bumping this is a deliberate,
+  # reviewable act; the value also lands in the release notes and in
+  # kernels/BUILT_AGAINST.txt inside the tarball.
+  LINUX_BUILDER_VERSION: nixdev_0.1.0
 
 jobs:
   build:
@@ -50,11 +67,22 @@ jobs:
           echo "FROM ${{secrets.REHOSTING_ARC_REGISTRY}}/proxy/rehosting/embedded-toolchains:latest" | \
           docker buildx build -t embedded-toolchains:latest --load -
 
-      - name: Download kernel-devel-all from release if not present
+      - name: Download kernel-devel-all from the pinned linux_builder release
+        id: kernel_devel
         run: |
+          set -euo pipefail
+          VER="${{ inputs.linux_builder_version }}"
+          [ -n "$VER" ] || VER="${LINUX_BUILDER_VERSION}"
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+          echo "Building against linux_builder $VER"
           if [ ! -f local_packages/kernel-devel-all.tar.gz ]; then
             mkdir -p local_packages
-            curl -L -o local_packages/kernel-devel-all.tar.gz "https://github.com/rehosting/linux_builder/releases/latest/download/kernel-devel-all.tar.gz"
+            # -f so a bad tag fails here, loudly, instead of writing an HTML
+            # 404 body to the .tar.gz and failing later as a corrupt archive.
+            curl -fL -o local_packages/kernel-devel-all.tar.gz \
+              "https://github.com/rehosting/linux_builder/releases/download/$VER/kernel-devel-all.tar.gz"
+          else
+            echo "::warning::using a pre-existing local_packages/kernel-devel-all.tar.gz; it may not be $VER"
           fi
       - name: Install pigz
         run: |
@@ -62,6 +90,10 @@ jobs:
           sudo apt-get install -y pigz
 
       - name: Extract and build all modules
+        env:
+          # Recorded into kernels/BUILT_AGAINST.txt inside the tarball, so the
+          # pairing travels with the artifact rather than living only in CI logs.
+          LINUX_BUILDER_VERSION: ${{ steps.kernel_devel.outputs.version }}
         run: |
           ./build.sh --versions "4.10 6.13" \
             --image embedded-toolchains:latest \
@@ -94,6 +126,15 @@ jobs:
           name: Release ${{ steps.version.outputs.v-version }}
           body: |
             Release ${{ steps.version.outputs.v-version }}
+
+            Built against **linux_builder `${{ steps.kernel_devel.outputs.version }}`**.
+
+            These modules are only loadable on kernels from that linux_builder
+            release. A kernel built with a different toolchain rejects them at
+            insmod with `disagrees about version of symbol module_layout`,
+            because Kconfig resolves options like `CONFIG_STACKPROTECTOR_PER_TASK`
+            and `CONFIG_INIT_STACK_*` by probing the compiler, which changes the
+            module ABI even when the sources and config files are identical.
           draft: false
           generate_release_notes: true
           prerelease: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,5 +137,11 @@ jobs:
             module ABI even when the sources and config files are identical.
           draft: false
           generate_release_notes: true
-          prerelease: false
+          # dev_* tags publish as PRERELEASES; only main merges are full
+          # releases. GitHub's `releases/latest` is the newest non-prerelease,
+          # and `releases/latest/download/igloo_driver.tar.gz` is read by
+          # penguin's nix-dev.sh and by this repo's own test.yml -- so a dev_*
+          # build marked as a full release would silently become the driver
+          # everything picks up. Matches linux_builder's convention.
+          prerelease: ${{ startsWith(github.ref, 'refs/tags/dev_') }}
           files: igloo_driver.tar.gz

--- a/_in_container_build.sh
+++ b/_in_container_build.sh
@@ -189,6 +189,30 @@ echo "Completed module builds for all targets."
 
 echo "Creating igloo_driver.tar.gz archive in output directory..."
 cd "${OUTPUT_BASE}"
+
+# Record which kernel-devel these modules were compiled against.
+#
+# A .ko is only loadable by the exact kernel build it was compiled against:
+# modversion CRCs are derived from the kernel's headers and config, and the
+# config includes options Kconfig resolves by PROBING THE COMPILER
+# (CONFIG_STACKPROTECTOR_PER_TASK, CONFIG_INIT_STACK_*, the CC_HAS_* family).
+# So a different toolchain in linux_builder yields a different ABI even with
+# identical sources and identical config files.
+#
+# That is not hypothetical: pairing v0.0.96 with nix-built kernels put 129 of
+# 221 CRCs out of agreement, and the only symptom was
+#   "igloo: disagrees about version of symbol module_layout"
+# followed by a guest panic. Nothing in the release said what it was built
+# against, so the mismatch was undiscoverable until boot. This file makes the
+# pairing inspectable.
+cat > kernels/BUILT_AGAINST.txt <<EOF
+linux_builder: ${LINUX_BUILDER_VERSION:-unknown}
+
+These modules are ONLY loadable on kernels from that linux_builder release.
+A kernel built by any other toolchain will reject them with
+"disagrees about version of symbol module_layout" at insmod.
+EOF
+
 tar --use-compress-program=pigz -cf "/app/igloo_driver.tar.gz" kernels
 echo "Archive created at /app/igloo_driver.tar.gz"
 

--- a/build.sh
+++ b/build.sh
@@ -174,6 +174,7 @@ BUILD_OUTPUT_MOUNT_SRC="$(rewrite_mount "$BUILD_OUTPUT_DIR")"
 # Run the container with proper environment variables and mounts
 docker run ${INTERACTIVE} --rm \
     -e RELEASE="${RELEASE}" \
+    -e LINUX_BUILDER_VERSION="${LINUX_BUILDER_VERSION:-}" \
     -e HOST_UID="$(id -u)" -e HOST_GID="$(id -g)" \
     -v "$KERNEL_DEVEL_MOUNT_SRC":/kernel-devel:ro \
     -v "$APP_MOUNT_SRC":/app \


### PR DESCRIPTION
The kernel headers this repo builds against came from

```
https://github.com/rehosting/linux_builder/releases/latest/download/kernel-devel-all.tar.gz
```

a **floating reference**. A `.ko` is loadable only by the exact kernel build it
was compiled against, so the modules in any given igloo_driver release silently
depended on whatever linux_builder had published most recently — and nothing,
anywhere, recorded which one that was.

## How this surfaced

rehosting/penguin#932 switches penguin's kernels to linux_builder's nix path.
Every 6.13 target failed. The kernel booted fine, then:

```
[    4.412173] igloo: disagrees about version of symbol module_layout
insmod: can't insert '/igloo/boot/igloo.ko': invalid module format
[    4.535221] Kernel panic - not syncing: Attempted to kill init!
```

No driver, no hypercalls, all 142 verifier tests fail with empty output.
Comparing the released `igloo.ko.armel` against one built from the same source
against the nix kernel: **129 of 221 modversion CRCs disagree.**

The driver source was not the problem — it is the *same commit* (linux_builder
pins `243c889e`; `v0.0.96` **is** `243c889e`).

## Why the ABI moved

The two kernels differ in **21 config lines, every one a compiler-capability
probe**:

```
CONFIG_CC_VERSION_TEXT  "arm-linux-musleabi-gcc (GCC) 11.2.1"  ->  "...Buildroot... 13.3.0"
CONFIG_GCC_VERSION      110201                                 ->  130300
CONFIG_INIT_STACK_NONE=y                                       ->  CONFIG_INIT_STACK_ALL_ZERO=y
                                                               ->  CONFIG_STACKPROTECTOR_PER_TASK=y
CONFIG_GCC_ASM_GOTO_OUTPUT_BROKEN=y                            ->  CONFIG_CC_HAS_ASM_GOTO_OUTPUT=y
```

Kconfig asks the compiler what it supports. linux_builder's nix path pins a
newer toolchain than the old unversioned `wget musl.cc/*-cross.tgz` downloads,
so more capabilities are available, stack-init and per-task stack-protector
switch on, struct layouts move, and the module ABI changes — **from identical
sources and identical config files**.

This is not a bug in either repo. It is the consequence of pinning the
toolchain, and it means the kernel/driver coupling — which was always real —
is now visible. It will recur every time either side's toolchain moves.

## What this changes

- **`LINUX_BUILDER_VERSION` is an explicit pin**, bumped deliberately and
  visibly in review instead of drifting whenever linux_builder publishes.
- **A `workflow_dispatch` input overrides it**, so a bump can be validated
  without cutting a release — the release step only runs on `push`.
- **`curl -f`**, so a bad tag fails at the download rather than writing a 404
  page into the `.tar.gz` and failing later as a corrupt archive.
- **The version is recorded twice**: `kernels/BUILT_AGAINST.txt` inside the
  tarball, and the release notes. The pairing now travels with the artifact and
  is inspectable without CI-log access.

## Sequencing — please read before merging

Pinned to **`nixdev_0.1.0`**, linux_builder's first nix-built release
(rehosting/linux_builder#59, still open). Consequences:

- Merging this means **the next igloo_driver release targets nix-built
  kernels** and will not load on the Docker-built ones.
- Consumers must bump kernels and driver **together**. penguin currently pins
  `kernels` v3.6.5 + `igloo-driver` v0.0.96, a matched pair; #932 moves both.
- `nixdev_0.1.0` is a prerelease from an unmerged branch. Once #59 lands and
  cuts a stable tag, this pin should move to it.

To validate before merging: run the workflow via `workflow_dispatch` with
`linux_builder_version` set. It builds and uploads the artifact without
releasing.

## Not done here

The durable fix is a flake with linux_builder as an input, so the pairing lives
in `flake.lock` and kernelsmith's `buildModule` — which takes the kernel
derivation as an input precisely so this mismatch is unrepresentable — enforces
it by construction. That is a larger change; this makes the coupling explicit
and recorded first.
